### PR TITLE
add REST resource to engine

### DIFF
--- a/examples/rest/main.go
+++ b/examples/rest/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/twharmon/goweb"
+)
+
+func main() {
+	app := goweb.New()
+	t := New()
+	app.Resource("/todos", &t)
+	app.Run(":8080")
+}

--- a/examples/rest/todo.go
+++ b/examples/rest/todo.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"github.com/twharmon/goweb"
+	"strconv"
+)
+
+type Todo struct {
+	Text string
+}
+type todoResource struct {
+	Todos   map[string]Todo
+	counter int
+}
+
+func New() todoResource {
+	return todoResource{
+		Todos:   make(map[string]Todo),
+		counter: 0,
+	}
+}
+func (t todoResource) Index(c *goweb.Context) goweb.Responder {
+	fmt.Println(t.Todos)
+	return c.JSON(t.Todos)
+}
+
+func (t todoResource) Get(c *goweb.Context) goweb.Responder {
+	id := c.Param(t.Identifier())
+	return c.JSON(t.Todos[id])
+}
+
+func (t *todoResource) Put(c *goweb.Context) goweb.Responder {
+	id := c.Param(t.Identifier())
+	t.Todos[id] = Todo{"put called"}
+	return c.JSON(t.Todos[id])
+}
+
+func (t *todoResource) Delete(c *goweb.Context) goweb.Responder {
+	delete(t.Todos, c.Param(t.Identifier()))
+	return c.JSON(len(t.Todos))
+}
+
+func (t *todoResource) Post(c *goweb.Context) goweb.Responder {
+	id := t.counter
+	t.counter++
+	t.Todos[strconv.Itoa(id)] = Todo{Text: "new from post"}
+	return c.JSON(id)
+}
+
+func (t todoResource) Identifier() string {
+	return "id"
+}

--- a/resource.go
+++ b/resource.go
@@ -1,0 +1,25 @@
+package goweb
+
+import (
+	"fmt"
+	"net/http"
+)
+
+//Resource creates multiple REST handlers from given interface.
+func (e *Engine) Resource(resourceName string, r iResource) {
+	resourcePath := fmt.Sprintf("%s/{%s}", resourceName, r.Identifier())
+	e.registerRoute(http.MethodGet, resourceName, r.Index)
+	e.registerRoute(http.MethodGet, resourcePath, r.Get)
+	e.registerRoute(http.MethodPut, resourcePath, r.Put)
+	e.registerRoute(http.MethodDelete, resourcePath, r.Delete)
+	e.registerRoute(http.MethodPost, resourceName, r.Post)
+}
+
+type iResource interface {
+	Index(c *Context) Responder
+	Get(c *Context) Responder
+	Put(c *Context) Responder
+	Delete(c *Context) Responder
+	Post(c *Context) Responder
+	Identifier() string
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,47 @@
+package goweb_test
+
+import (
+	"net/http"
+	"testing"
+)
+import "github.com/twharmon/goweb"
+
+type todoResource struct {
+}
+
+func (t todoResource) Put(c *goweb.Context) goweb.Responder {
+	return c.Text(c.Param(t.Identifier()))
+}
+
+func (t todoResource) Delete(c *goweb.Context) goweb.Responder {
+	return c.Text(c.Param(t.Identifier()))
+}
+
+func (t todoResource) Post(c *goweb.Context) goweb.Responder {
+	return c.Text("4")
+}
+
+func (t todoResource) Index(c *goweb.Context) goweb.Responder {
+
+	return c.Text("index")
+
+}
+func (t todoResource) Get(c *goweb.Context) goweb.Responder {
+	return c.Text(c.Param(t.Identifier()))
+}
+func (t todoResource) Identifier() string {
+	return "id"
+}
+func TestResource(t *testing.T) {
+	app := goweb.New()
+
+	todos := todoResource{}
+	app.Resource("/todo", todos)
+
+	assert(t, app, "GET", "/todo", nil, nil, http.StatusOK, "index")
+	assert(t, app, "GET", "/todo/1", nil, nil, http.StatusOK, "1")
+	assert(t, app, "PUT", "/todo/2", nil, nil, http.StatusOK, "2")
+	assert(t, app, "DELETE", "/todo/3", nil, nil, http.StatusOK, "3")
+	assert(t, app, "POST", "/todo", nil, nil, http.StatusOK, "4")
+
+}


### PR DESCRIPTION
This PR adds a resource endpoint to the engine that makes it possible to use a REST resource with goweb. There is an example code that adds an in-memory todos API. 

this makes it clearer for someone to implement CRUD operations, and they can do it inside their own business logic without touching goweb logic. 

This PR also removes go.sum from .gitignore, because golang normally wont update go.sum unless asked for it explicitly. 

closes #61 

